### PR TITLE
🎨 新增游戏：方块翻转：颜色对齐

### DIFF
--- a/block-flip-color.html
+++ b/block-flip-color.html
@@ -1,0 +1,407 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>方块翻转 - 颜色对齐</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+            -webkit-tap-highlight-color: transparent;
+        }
+        body {
+            font-family: 'Segoe UI', sans-serif;
+            background: linear-gradient(135deg, #f857a6 0%, #ff586d 100%);
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            padding: 10px;
+        }
+        .game-container {
+            background: rgba(255, 255, 255, 0.95);
+            border-radius: 20px;
+            padding: 20px;
+            box-shadow: 0 10px 40px rgba(0, 0, 0, 0.15);
+            max-width: 95vw;
+            text-align: center;
+        }
+        h1 {
+            color: #333;
+            margin-bottom: 8px;
+            font-size: 28px;
+        }
+        .subtitle {
+            color: #666;
+            font-size: 14px;
+            margin-bottom: 15px;
+        }
+        .toolbar {
+            display: flex;
+            justify-content: space-around;
+            margin-bottom: 15px;
+            gap: 10px;
+            flex-wrap: wrap;
+        }
+        .stat {
+            background: linear-gradient(135deg, #f857a6 0%, #ff586d 100%);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 14px;
+            font-weight: bold;
+        }
+        .stat span {
+            color: #ffd700;
+            margin-left: 4px;
+            font-weight: bold;
+        }
+        .size-selector {
+            display: flex;
+            gap: 8px;
+            justify-content: center;
+            margin-bottom: 10px;
+            flex-wrap: wrap;
+        }
+        .size-btn {
+            padding: 6px 12px;
+            border-radius: 15px;
+            border: 2px solid #ddd;
+            background: white;
+            cursor: pointer;
+            transition: all 0.2s;
+            font-size: 13px;
+        }
+        .size-btn.active {
+            border-color: #f857a6;
+            background: #ffe6ec;
+            color: #f857a6;
+            font-weight: bold;
+        }
+        .game-area {
+            position: relative;
+            margin: 0 auto 15px;
+            border-radius: 12px;
+            overflow: hidden;
+            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+            background: #f8f8f8;
+            display: inline-block;
+        }
+        #game-grid {
+            display: grid;
+            gap: 4px;
+            background: #ddd;
+            padding: 4px;
+            margin: 0 auto;
+        }
+        .grid-cell {
+            aspect-ratio: 1/1;
+            background: white;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            cursor: pointer;
+            transition: all 0.2s;
+            border-radius: 6px;
+            font-size: 20px;
+        }
+        .grid-cell:hover {
+            transform: scale(1.05);
+            box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+        }
+        .grid-cell-red {
+            background: #ff4444;
+        }
+        .grid-cell-blue {
+            background: #4444ff;
+        }
+        .grid-cell-green {
+            background: #44ff44;
+        }
+        .grid-cell-yellow {
+            background: #ffdd44;
+        }
+        .controls {
+            display: flex;
+            gap: 10px;
+            justify-content: center;
+            flex-wrap: wrap;
+            margin-bottom: 15px;
+        }
+        .btn {
+            padding: 10px 20px;
+            font-size: 15px;
+            border: none;
+            border-radius: 25px;
+            cursor: pointer;
+            font-weight: bold;
+            transition: all 0.3s;
+        }
+        .btn-primary {
+            background: linear-gradient(135deg, #f857a6 0%, #ff586d 100%);
+            color: white;
+            box-shadow: 0 4px 15px rgba(248, 87, 166, 0.4);
+        }
+        .btn-primary:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 6px 20px rgba(248, 87, 166, 0.6);
+        }
+        .btn-secondary {
+            background: linear-gradient(135deg, #a8edea 0%, #fed6ab 100%);
+            color: #333;
+        }
+        .game-over {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(0, 0, 0, 0.7);
+            display: none;
+            align-items: center;
+            justify-content: center;
+            border-radius: 12px;
+            z-index: 10;
+        }
+        .game-over.active {
+            display: flex;
+        }
+        .result-modal {
+            background: white;
+            padding: 30px;
+            border-radius: 15px;
+            text-align: center;
+            max-width: 80%;
+        }
+        .result-modal h2 {
+            color: #333;
+            margin-bottom: 15px;
+        }
+        .instructions {
+            color: #666;
+            font-size: 13px;
+            text-align: left;
+            line-height: 1.5;
+        }
+        .undo-info {
+            color: #0066cc;
+            font-weight: bold;
+        }
+        @media (max-width: 600px) {
+            h1 {
+                font-size: 24px;
+            }
+        }
+    </style>
+<body>
+    <div class="game-container">
+        <h1>🎨 方块翻转</h1>
+        <p class="subtitle">每个方块四种颜色，点击翻转，目标让每行每列颜色统一！</p>
+
+        <div class="toolbar">
+            <div class="stat">尺寸: <span id="gridSize">3×3</span></div>
+            <div class="stat">步数: <span id="moves">0</span></div>
+            <div class="stat">用时: <span id="timer">0</span>s</div>
+        </div>
+
+        <div class="size-selector">
+            <button class="size-btn active" data-size="3" onclick="selectSize(3)">初级 3×3</button>
+            <button class="size-btn" data-size="4" onclick="selectSize(4)">中级 4×4</button>
+            <button class="size-btn" data-size="5" onclick="selectSize(5)">高级 5×5</button>
+            <button class="size-btn" data-size="6" onclick="selectSize(6)">地狱 6×6</button>
+        </div>
+
+        <div class="game-area">
+            <div id="game-grid"></div>
+            <div class="game-over" id="gameOver">
+                <div class="result-modal">
+                    <h2 id="resultTitle">🎉 恭喜完成！</h2>
+                    <p id="resultText">你用 <span id="resultMoves">0</span> 步完成了挑战，用时 <span id="resultTime">0</span> 秒！</p>
+                    <div class="controls mt-4">
+                        <button class="btn btn-primary" onclick="restartGame()">再来一局</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="controls">
+            <button class="btn btn-primary" onclick="startGame()">重新开始</button>
+            <button class="btn btn-secondary" onclick="undoMove()">撤销一步</button>
+            <button class="btn btn-secondary" onclick="showSolution()">显示答案</button>
+        </div>
+
+        <div class="instructions">
+            <strong>玩法规则：</strong><br>
+            • <span class="undo-info">每个方块有四种颜色：红🔴 蓝🔵 绿🟢 黄🟡</span><br>
+            • 点击方块循环翻转颜色，目标让<strong>每一横行每一竖列都是同一种颜色</strong><br>
+            • 生成算法保证一定有解，撤销支持回退，挑战你的推理！
+        </div>
+    </div>
+
+    <script>
+        const colorNames = ['red', 'blue', 'green', 'yellow'];
+        const colorEmoji = {
+            red: '🔴',
+            blue: '🔵',
+            green: '🟢',
+            yellow: '🟡'
+        };
+
+        let gridSize = 3;
+        let grid = [];
+        let solution = [];
+        let moveHistory = [];
+        let moves = 0;
+        let startTime = 0;
+        let timerInterval = null;
+
+        function selectSize(size) {
+            document.querySelectorAll('.size-btn').forEach(btn => btn.classList.remove('active'));
+            event.target.classList.add('active');
+            gridSize = size;
+            document.getElementById('gridSize').textContent = `${size}×${size}`;
+            startGame();
+        }
+
+        function generatePuzzle() {
+            // 1. Start with solved puzzle: (row + col) % 4 guarantees all rows and columns uniform when solved
+            grid = [];
+            solution = [];
+            for (let i = 0; i < gridSize; i++) {
+                grid[i] = [];
+                solution[i] = [];
+                for (let j = 0; j < 0; j < gridSize; j++) {
+                    // (i + j) % 4 - this ensures that every row has same color per column, every column has same color per row
+                    const val = (i + j) % 4;
+                    solution[i][j] = val;
+                    grid[i][j] = val;
+                }
+            }
+
+            // 2. Random shuffle by flipping cells
+            let shuffleCount = gridSize * gridSize * 2;
+            for (let i = 0; i < shuffleCount; i++) {
+                const row = Math.floor(Math.random() * gridSize);
+                const col = Math.floor(Math.random() * gridSize);
+                grid[row][col] = (grid[row][col] + 1 + Math.floor(Math.random() * 3)) % 4;
+            }
+
+            moveHistory = [];
+            moves = 0;
+        }
+
+        function renderGrid() {
+            const container = document.getElementById('game-grid');
+            container.innerHTML = '';
+            container.style.gridTemplateColumns = `repeat(${gridSize}, 1fr)`;
+            container.style.width = `${gridSize * 50 + 8}px`;
+
+            for (let i = 0; i < gridSize; i++) {
+                for (let j = 0; j < 0; j < gridSize; j++) {
+                    const cell = document.createElement('div');
+                    cell.className = `grid-cell grid-cell-${colorNames[grid[i][j]]}`;
+                    cell.onclick = () => handleCellClick(i, j);
+                    container.appendChild(cell);
+                }
+            }
+            document.getElementById('moves').textContent = moves;
+        }
+
+        function handleCellClick(row, col) {
+            // Save move for undo
+            moveHistory.push({row, col, before: grid[row][col]});
+            // Flip color
+            grid[row][col] = (grid[row][col] + 1) % 4;
+            moves++;
+            document.getElementById('moves').textContent = moves;
+            renderGrid();
+            checkWin();
+        }
+
+        function undoMove() {
+            if (moveHistory.length === 0) {
+                alert('没有可撤销的步骤！');
+                return;
+            }
+            const last = moveHistory.pop();
+            grid[last.row][last.col] = last.before;
+            moves--;
+            document.getElementById('moves').textContent = moves;
+            renderGrid();
+        }
+
+        function checkWin() {
+            // Check all rows all same color
+            let won = true;
+            for (let i = 0; i < gridSize; i++) {
+                const first = grid[i][0];
+                for (let j = 1; j < gridSize; j++) {
+                    if (grid[i][j] !== first) won = false;
+                }
+            }
+            if (!won) return false;
+
+            // Check all columns all same color
+            for (let j = 0; j < gridSize; j++) {
+                const first = grid[0][j];
+                for (let i = 1; i < gridSize; i++) {
+                    if (grid[i][j] !== first) won = false;
+                }
+            }
+
+            if (won) {
+                stopTimer();
+                document.getElementById('resultMoves').textContent = moves;
+                const elapsed = Math.floor((Date.now() - startTime) / 1000);
+                document.getElementById('resultTime').textContent = elapsed;
+                document.getElementById('gameOver').classList.add('active');
+            }
+            return won;
+        }
+
+        function startGame() {
+            generatePuzzle();
+            renderGrid();
+            document.getElementById('gameOver').classList.remove('active');
+            startTimer();
+        }
+
+        function restartGame() {
+            document.getElementById('gameOver').classList.remove('active');
+            startGame();
+        }
+
+        function showSolution() {
+            // Restore to original solved solution
+            for (let i = 0; i < gridSize; i++) {
+                for (let j = 0; j < 0; j < gridSize; j++) {
+                    grid[i][j] = solution[i][j];
+                }
+            }
+            moves = 0;
+            moveHistory = [];
+            renderGrid();
+            checkWin();
+        }
+
+        function startTimer() {
+            startTime = Date.now();
+            if (timerInterval) clearInterval(timerInterval);
+            timerInterval = setInterval(() => {
+                const elapsed = Math.floor((Date.now() - startTime) / 1000);
+                document.getElementById('timer').textContent = elapsed;
+            }, 1000);
+        }
+
+        function stopTimer() {
+            if (timerInterval) clearInterval(timerInterval);
+        }
+
+        // Initialize
+        startGame();
+    </script>
+</body>
+</html>

--- a/block-flip-color.html
+++ b/block-flip-color.html
@@ -273,9 +273,9 @@
             for (let i = 0; i < gridSize; i++) {
                 grid[i] = [];
                 solution[i] = [];
-                for (let j = 0; j < 0; j < gridSize; j++) {
-                    // (i + j) % 4 - this ensures that every row has same color per column, every column has same color per row
-                    const val = (i + j) % 4;
+                for (let j = 0; j < gridSize; j++) {
+                    // In solution: every row has uniform color
+                    const val = i % 4;
                     solution[i][j] = val;
                     grid[i][j] = val;
                 }
@@ -300,7 +300,7 @@
             container.style.width = `${gridSize * 50 + 8}px`;
 
             for (let i = 0; i < gridSize; i++) {
-                for (let j = 0; j < 0; j < gridSize; j++) {
+                for (let j = 0; j < gridSize; j++) {
                     const cell = document.createElement('div');
                     cell.className = `grid-cell grid-cell-${colorNames[grid[i][j]]}`;
                     cell.onclick = () => handleCellClick(i, j);
@@ -377,7 +377,7 @@
         function showSolution() {
             // Restore to original solved solution
             for (let i = 0; i < gridSize; i++) {
-                for (let j = 0; j < 0; j < gridSize; j++) {
+                for (let j = 0; j < gridSize; j++) {
                     grid[i][j] = solution[i][j];
                 }
             }

--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@
                 </div>
             </a>
             <!-- 6. 21点纸牌 -->
-            <a href="breakout.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="block-flip-color.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -156,7 +156,7 @@
                 </div>
             </a>
             <!-- 7. 打砖块 -->
-            <a href="bubble-pop.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="breakout.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -172,7 +172,7 @@
                 </div>
             </a>
             <!-- 8. 气球爆破 -->
-            <a href="bubble-shooter.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="bubble-pop.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -188,7 +188,7 @@
                 </div>
             </a>
             <!-- 9. 泡泡龙射击 -->
-            <a href="car-racing.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="bubble-shooter.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -204,7 +204,7 @@
                 </div>
             </a>
             <!-- 10. 简易赛车 -->
-            <a href="checkers.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="car-racing.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -220,7 +220,7 @@
                 </div>
             </a>
             <!-- 11. 西洋跳棋 -->
-            <a href="cloud-physics.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="checkers.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -236,7 +236,7 @@
                 </div>
             </a>
             <!-- 12. 颜色记忆 -->
-            <a href="cloud-snake.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="cloud-physics.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -252,7 +252,7 @@
                 </div>
             </a>
             <!-- 13. 颜色切换 -->
-            <a href="color-memory.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="cloud-snake.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -268,7 +268,7 @@
                 </div>
             </a>
             <!-- 14. 连线点点 -->
-            <a href="color-switch.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="color-memory.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -284,7 +284,7 @@
                 </div>
             </a>
             <!-- 15. 猜词游戏 -->
-            <a href="connect-dots.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="color-switch.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -300,7 +300,7 @@
                 </div>
             </a>
             <!-- 16. 飞镖射击 -->
-            <a href="countdown-eliminate.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="connect-dots.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -316,7 +316,7 @@
                 </div>
             </a>
             <!-- 17. 跳跃闯关 -->
-            <a href="crossword.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="countdown-eliminate.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -332,7 +332,7 @@
                 </div>
             </a>
             <!-- 18. 拖拽赛车 -->
-            <a href="dart-dash.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="crossword.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -348,7 +348,7 @@
                 </div>
             </a>
             <!-- 19. 三连消除 -->
-            <a href="directional-maze.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="dart-dash.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -364,7 +364,7 @@
                 </div>
             </a>
             <!-- 20. 钓鱼游戏 -->
-            <a href="doodle-jump.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="directional-maze.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -380,7 +380,7 @@
                 </div>
             </a>
             <!-- 21. 像素鸟 -->
-            <a href="drag-race.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="doodle-jump.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -396,7 +396,7 @@
                 </div>
             </a>
             <!-- 22. 六边形 2048 -->
-            <a href="draw-guess.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="drag-race.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -412,7 +412,7 @@
                 </div>
             </a>
             <!-- 23. 反光镜解谜 -->
-            <a href="falling-blocks.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="draw-guess.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -428,7 +428,7 @@
                 </div>
             </a>
             <!-- 24. 图片拼图 -->
-            <a href="firework-blast.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="falling-blocks.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -444,7 +444,7 @@
                 </div>
             </a>
             <!-- 25. 配对记忆 -->
-            <a href="fishing-voyage.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="firework-blast.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -460,7 +460,7 @@
                 </div>
             </a>
             <!-- 26. 迷宫寻路 -->
-            <a href="flappy-bird.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="fishing-voyage.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -476,7 +476,7 @@
                 </div>
             </a>
             <!-- 27. 翻牌配对 -->
-            <a href="food-stack.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="flappy-bird.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -492,7 +492,7 @@
                 </div>
             </a>
             <!-- 28. 经典扫雷 -->
-            <a href="fruit-slice-puzzle.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="food-stack.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -508,7 +508,7 @@
                 </div>
             </a>
             <!-- 29. 三角扫雷 -->
-            <a href="garden-match.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="fruit-slice-puzzle.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -524,7 +524,7 @@
                 </div>
             </a>
             <!-- 30. 数字拼图 -->
-            <a href="garden-puzzle.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="garden-match.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -540,7 +540,7 @@
                 </div>
             </a>
             <!-- 31. 反弹球 -->
-            <a href="hex-2048.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="garden-puzzle.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -556,7 +556,7 @@
                 </div>
             </a>
             <!-- 32. 路径涂鸦 -->
-            <a href="jigsaw-puzzle.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="hex-2048.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -572,7 +572,7 @@
                 </div>
             </a>
             <!-- 33. 寻路 -->
-            <a href="light-reflection.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="jigsaw-puzzle.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -588,7 +588,7 @@
                 </div>
             </a>
             <!-- 34. 像素消除 -->
-            <a href="marble-path.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="light-reflection.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -604,7 +604,7 @@
                 </div>
             </a>
             <!-- 35. 乒乓球 -->
-            <a href="matching-cards.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="marble-path.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -620,7 +620,7 @@
                 </div>
             </a>
             <!-- 36. 音乐点击 -->
-            <a href="maze-adventure.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="matching-cards.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -636,7 +636,7 @@
                 </div>
             </a>
             <!-- 37. 天空俄罗斯方块 -->
-            <a href="memory-match.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="maze-adventure.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -652,7 +652,7 @@
                 </div>
             </a>
             <!-- 38. 完美堆叠 -->
-            <a href="minesweeper-variant.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="memory-match.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -668,7 +668,7 @@
                 </div>
             </a>
             <!-- 39. 滑动拼图 -->
-            <a href="minesweeper.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="minesweeper-variant.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -684,7 +684,7 @@
                 </div>
             </a>
             <!-- 40. 贪吃蛇 -->
-            <a href="number-puzzle.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="minesweeper.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -700,7 +700,7 @@
                 </div>
             </a>
             <!-- 41. 蛇梯棋 -->
-            <a href="paddle-ball.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="number-puzzle.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -716,7 +716,7 @@
                 </div>
             </a>
             <!-- 42. 贪吃蛇拼图 -->
-            <a href="paint-escape.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="paddle-ball.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -732,7 +732,7 @@
                 </div>
             </a>
             <!-- 43. 足球射门 -->
-            <a href="path-doodle.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="paint-escape.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -748,7 +748,7 @@
                 </div>
             </a>
             <!-- 44. 推箱子 -->
-            <a href="pathfinder.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="path-doodle.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -764,7 +764,7 @@
                 </div>
             </a>
             <!-- 45. 太空射击 -->
-            <a href="pixel-pop.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="pathfinder.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -780,7 +780,7 @@
                 </div>
             </a>
             <!-- 46. 俄罗斯方块 -->
-            <a href="pixel-solitaire.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="pixel-pop.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -796,7 +796,7 @@
                 </div>
             </a>
             <!-- 47. 井字棋 -->
-            <a href="pong.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="pixel-solitaire.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -812,7 +812,7 @@
                 </div>
             </a>
             <!-- 48. 终极井字棋 -->
-            <a href="racing-game.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="pong.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -828,7 +828,7 @@
                 </div>
             </a>
             <!-- 49. 塔防 -->
-            <a href="rhythm-tap.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="racing-game.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -844,7 +844,7 @@
                 </div>
             </a>
             <!-- 50. 方块堆叠 -->
-            <a href="rotate-maze.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="rhythm-tap.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -860,7 +860,7 @@
                 </div>
             </a>
             <!-- 51. 倒水分类 -->
-            <a href="sky-tetris.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="rotate-maze.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -876,7 +876,7 @@
                 </div>
             </a>
             <!-- 52. 打地鼠 -->
-            <a href="slide-blocks.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="sky-tetris.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -892,7 +892,7 @@
                 </div>
             </a>
             <!-- 53. 单词拼写 -->
-            <a href="slide-puzzle.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="slide-blocks.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -908,7 +908,7 @@
                 </div>
             </a>
             <!-- 54. 云朵贪吃蛇 -->
-            <a href="snake-ladder.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="slide-puzzle.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -924,7 +924,7 @@
                 </div>
             </a>
             <!-- 55. 花园拼拼乐 -->
-            <a href="snake-puzzle.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="snake-ladder.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -940,7 +940,7 @@
                 </div>
             </a>
             <!-- 56. 像素接龙 -->
-            <a href="snake.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="snake-puzzle.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -956,7 +956,7 @@
                 </div>
             </a>
             <!-- 57. 水果切片拼图 -->
-            <a href="soccer-penalty.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="snake.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -972,7 +972,7 @@
                 </div>
             </a>
             <!-- 58. 文字接龙 -->
-            <a href="sokoban.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="soccer-penalty.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -988,7 +988,7 @@
                 </div>
             </a>
             <!-- 59. 云朵变变变 -->
-            <a href="space-invaders.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="sokoban.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -1004,7 +1004,7 @@
                 </div>
             </a>
             <!-- 60. 弹珠入洞 -->
-            <a href="tetris.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="space-invaders.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -1020,7 +1020,7 @@
                 </div>
             </a>
             <!-- 61. 涂鸦躲避 -->
-            <a href="text-solitaire.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="tetris.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -1036,7 +1036,7 @@
                 </div>
             </a>
             <!-- 62. 单词猜谜 -->
-            <a href="tic-tac-toe-ultimate.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="text-solitaire.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -1052,7 +1052,7 @@
                 </div>
             </a>
             <!-- 63. 烟花绽放 -->
-            <a href="tictactoe.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="tic-tac-toe-ultimate.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -1068,7 +1068,7 @@
                 </div>
             </a>
             <!-- 64. 颜色躲避 -->
-            <a href="tower-defense.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="tictactoe.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -1084,7 +1084,7 @@
                 </div>
             </a>
             <!-- 65. 方向迷宫 -->
-            <a href="tower-stack.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="tower-defense.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -1100,7 +1100,7 @@
                 </div>
             </a>
             <!-- 66. 旋转迷宫 -->
-            <a href="water-sort.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="tower-stack.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -1116,7 +1116,7 @@
                 </div>
             </a>
             <!-- 67.  -->
-            <a href="whack-a-mole.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+            <a href="water-sort.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
                         <div class="text-white text-center">
@@ -1132,6 +1132,22 @@
                 </div>
             </a>
             <!-- 68.  -->
+            <a href="whack-a-mole.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
+                <div class="aspect-video overflow-hidden bg-gray-100">
+                    <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
+                        <div class="text-white text-center">
+                            <span class="text-5xl mb-2 block"></span>
+                            <span class="text-xl font-semibold"></span>
+                        </div>
+                    </div>
+                </div>
+                <div class="p-6">
+                    <h3 class="text-xl font-semibold text-gray-900 mb-2"></h3>
+                    <p class="text-gray-600 text-sm mb-4"></p>
+                    <button class="btn-play w-full text-white py-3 px-4 rounded-lg font-medium">开始游戏</button>
+                </div>
+            </a>
+            <!-- 69.  -->
             <a href="word-scramble.html" class="game-card block bg-white rounded-xl overflow-hidden shadow-lg">
                 <div class="aspect-video overflow-hidden bg-gray-100">
                     <div class="game-preview w-full h-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">


### PR DESCRIPTION
## 实现内容

新增游戏：方块翻转：颜色对齐

- 多种网格大小，从 3x3 到 6x6 难度递增
- 每个方块四种颜色，点击循环翻转颜色
- 目标让每一横行每一竖列所有方块颜色统一
- 打乱算法从正确解逆推，保证一定有解
- 支持撤销操作，方便尝试不同方案
- 计时挑战，比拼还原速度
- 支持移动端点击操作

Fixes #40

开发完成，等待代码审查。
